### PR TITLE
Add constructor with weight function

### DIFF
--- a/WeightedList.cs
+++ b/WeightedList.cs
@@ -27,6 +27,20 @@ namespace KaimiraGames
         }
 
         /// <summary>
+        /// Create a WeightedList with the provided items, function to get weight per item and an optional System.Random.
+        /// </summary>
+        public WeightedList(IEnumerable<T> listItems, Func<T, int> getWeight, Random rand = null)
+        {
+            _rand = rand ?? new Random();
+            foreach (var item in listItems)
+            {
+                _list.Add(item);
+                _weights.Add(getWeight(item));
+            }
+            Recalculate();
+        }
+
+        /// <summary>
         /// Create a WeightedList with the provided items and an optional System.Random.
         /// </summary>
         public WeightedList(ICollection<WeightedListItem<T>> listItems, Random rand = null)


### PR DESCRIPTION
Added constructor to initialize WeightedList with item list and a function to get weight per item.

Adds some convenience by utilizing well-established patterns in C#, bypassing the need to either individually add item weight one at a time or create a `ICollection<WeightedListItem<T>>`.

Example usage:
```csharp
class WeightedItem
{
    public int Weight { get; set; }
}

List<WeightedItem> _options { get; set; }
WeightedList<WeightedItem> _weightedList ;

_weightedList = new WeightedList<WeightedItem>(_options, x => x.Weight);
```